### PR TITLE
Fix usability issues - remove async getEventBus  and unregister

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,41 +118,6 @@ Custom log writers can be created by extending `LogWriter` class:
   The `_write` function will be called when `LogWriter.write(data)`
   is called directly, or via `Logger.log(data)` calls
 
-## Unregistering log writers
-
-Registered log writers are stored in EventBus private properties.
-
-When loggers or log writers are not needed, registrations can be removed by running
-on of the following commands:
-
-- `logger.unregister()` - unregister the logger and its association to writers
-- `logWriter.unregister()` - unregister writer and its association to loggers
-
-This will allow JavaScript to garbage collect corresponding loggers and log writers
-when they are no longer used, freeing memory.
-
-Generally speaking, unregistering is not required when loggers should exist through
-the entire lifetime application execution. There are situations, however, when loggers
-and created dynamically and should only exist for a brief period of time.
-
-For example, a REST API service can register a new logger for each REST call and then
-terminate the logger once the request is fulfilled. In this model, one log writer will
-exist while the service is running, and new loggers will be created for each REST API
-request:
-
-```ts
-
-const writer = new LogWriter({ loggerName: 'writer'})
-
-function request_handler(request, response, next) {
-  const logger = new Logger( {loggerName: 'L2', level: 'DEBUG', context:{user:props.auth.user}} )
-  writer.attachToLogger(logger, 'DEBUG', transformFn),
-  ...
-  logger.unregister()
-  return response.send()
-}
-```
-
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a pull request

--- a/src/logWriter.ts
+++ b/src/logWriter.ts
@@ -78,7 +78,7 @@ export abstract class LogWriter<
     if (cb) cb()
   }
 
-  async attachToLogger<TLogger extends Logger<any, any>>(
+  attachToLogger<TLogger extends Logger<any, any>>(
     logger: TLogger,
 
     /**
@@ -95,7 +95,7 @@ export abstract class LogWriter<
       TConfigA,
       TLogger extends Logger<any, infer TContext> ? TContext : never
     >
-  ): Promise<void> {
+  ): void {
     // type TData = TLogger extends Logger<infer U, any> ? U : never
     // type TContext = TLogger extends Logger<any, infer U> ? U : never
 
@@ -108,9 +108,9 @@ export abstract class LogWriter<
       this.write(data)
     }.bind(this)
 
-    const eventBus = await getEventBus()
+    const eventBus = getEventBus()
 
-    await eventBus.addMessageListener({
+    eventBus.addMessageListener({
       levelName,
       listener,
       logWriter: this,
@@ -151,10 +151,4 @@ export abstract class LogWriter<
    * Warning! Use _write when file writer needs to be used
    */
   protected abstract _write: WriteMethod<TFormattedData>
-
-  /** unregister the writer and its loggers */
-  async unregister() {
-    const eventBus = await getEventBus()
-    await eventBus.unregisterLogWriter(this)
-  }
 }

--- a/src/logWriters/fileLogWriter.ts
+++ b/src/logWriters/fileLogWriter.ts
@@ -101,21 +101,19 @@ export class FileLogWriter extends LogWriter<FileLogWriterData, FileLogWriterCon
     })
 
     stream.on('drain', () => {
-      getEventBus().then((v) => {
-        v.emit('log4ts:pause', {
-          pause: false,
-          className: this.constructor.name,
-          logWriterName: this.name,
-        })
-      })
-    })
-
-    getEventBus().then((v) => {
-      v.emit('log4ts:pause', {
+      const eventBus = getEventBus()
+      eventBus.emit('log4ts:pause', {
         pause: false,
         className: this.constructor.name,
         logWriterName: this.name,
       })
+    })
+
+    const eventBus = getEventBus()
+    eventBus.emit('log4ts:pause', {
+      pause: false,
+      className: this.constructor.name,
+      logWriterName: this.name,
     })
 
     return stream
@@ -132,12 +130,11 @@ export class FileLogWriter extends LogWriter<FileLogWriterData, FileLogWriterCon
 
     if (!this.writer.write(data + eol, 'utf8')) {
       //  writer returns `false` when stream needs to wait for the `'drain'` event to be emitted
-      getEventBus().then((v) => {
-        v.emit('log4ts:pause', {
-          pause: true,
-          className: this.constructor.name,
-          logWriterName: this.name,
-        })
+      const eventBus = getEventBus()
+      eventBus.emit('log4ts:pause', {
+        pause: true,
+        className: this.constructor.name,
+        logWriterName: this.name,
       })
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -140,7 +140,8 @@ export class Logger<TData extends any[], TContext extends Record<string, any> = 
       location: callStack,
       error,
     })
-    getEventBus().then((eventBus) => eventBus.send(loggingEvent))
+    const eventBus = getEventBus()
+    eventBus.send(loggingEvent)
   }
 
   addContext<K extends TContext extends undefined ? never : keyof TContext>(
@@ -157,12 +158,6 @@ export class Logger<TData extends any[], TContext extends Record<string, any> = 
 
   clearContext() {
     this.context = {} as TContext
-  }
-
-  /** unregister the logger and its writers */
-  async unregister() {
-    const eventBus = await getEventBus()
-    await eventBus.unregisterLogger(this)
   }
 
   setParseCallStackFunction(parseFunction?: ParseCallStackFunction) {


### PR DESCRIPTION
 remove async from `getEventBus`, `attachToLogger`,  remove `unregister`
 
- make `getEventBus` and `attachToLogger` sync function to avoid timing issues
- remove unregister events to avoid async code
  - reverses fc4b2ff46db610493837b195598df554a0611ff8 and a5c43d9df9db289b05f99d13f060cfea516bf553