### PR TITLE
v.0.0.7 - [BC] improve typings; rename Transformer to Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yarn add @panfiva/log4ts
 
 - **Shared log writers**
 
-  Attach multiple loggers to the same log writer with different transform functions.
+  Attach multiple loggers to the same log writer by customizing `Logger.transform()`.
   This allows users to send send different data shapes in a type-safe manner
 
 - **Graceful shutdown**
@@ -68,14 +68,14 @@ All examples are configured with process signal listeners to demonstrate event h
   - Writing to a rolling log file
   - Define data type of log function parameters
   - Process cleanup when `SIGINT` signal received
-  - Infer transform function parameters inside `<writer>.register()`
+  - Infer layout function parameters inside `<writer>.register()`
 
 - [Multi-File Log Writer](./src/examples/multiFile.ts)
 
   - Write to the same file using different loggers
   - Dynamically define which file will be used based on data attributes
   - Set and use logger context
-  - Explicitly define transform function data type to infer its parameters
+  - Explicitly define layout function data type to infer its parameters
 
 - [Splunk HEC Log Writer](./src/examples/splunkHec.ts)
 
@@ -183,15 +183,15 @@ See [Custom Context](src/examples/customContext.ts) example for details.
 
 ## Customize logger payload
 
-If logger is expected to receive different data shape, logger can be registered with
-a transform function that is built to handle different data shapes. This approach
+When multiple instances of a logger expect to receive different data formats,
+registered layout function must be to handle different data shapes. This approach
 has the following issues:
 
-- may increase complexity of registered transform function
-- may require changing data payload format to indicate its type, impacting ease of use
+- may increase complexity of registered layout function
+- may require changing logger log function args to differentiate input - impacts usability
 
 A better approach is to create a new logger class that uses `Logger.format()` to reformat
-user input before data is sent to the registered transformer.
+user input before data is sent to the registered layout function.
 
 See [Custom Logger Output](src/examples/customLoggerOutput.ts)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@panfiva/log4ts",
   "packageManager": "yarn@4.9.2",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Port of log4js-node to TypeScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/defaultParseCallStack.ts
+++ b/src/defaultParseCallStack.ts
@@ -2,13 +2,16 @@ import type { CallStack } from './types'
 
 const stackReg = /^(?:\s*)at (?:(.+) \()?(?:([^(]+?):(\d+):(\d+))\)?$/
 
-export type ParseCallStackFunction = (data: Error, skipIdx?: number) => CallStack | undefined
+export type ParseCallStackFunction = (
+  data: Error | Record<string, any>,
+  skipIdx?: number
+) => CallStack | undefined
 
 /**
  * Extracts callstack from error - returns an entry that generated the error
  */
 export const defaultParseCallStack: ParseCallStackFunction = (
-  data: Error,
+  data: Error | Record<string, any>,
   // The _log function is 3 levels deep, we need to skip those to make it to the callSite
   // Plus top entry is Error
   skipIdx = 4

--- a/src/examples/multiFile.ts
+++ b/src/examples/multiFile.ts
@@ -3,7 +3,7 @@ export DEBUG=log4ts:logWriter:multiFileLogWriter,log4ts:logWriter:shutdown,log4t
 yarn run build && node ./dist/examples/multiFile.js
 */
 
-import { Logger, MultiFileLogWriter, MultiFileLogWriterOptions, TransformerFnInferred } from '..'
+import { Logger, MultiFileLogWriter, MultiFileLogWriterOptions, LayoutFnInferred } from '..'
 
 import { configure_process } from './configure_process'
 
@@ -26,7 +26,7 @@ const logWriter = new MultiFileLogWriter('writer-name', options)
 type LoggerPayload = (string | number | boolean)[]
 
 // Example 1 - Add file name using context during logger creation
-// context value will be used in transformerFn
+// context value will be used in layoutFn
 const logger1 = new Logger<LoggerPayload, { filename: string }>({
   loggerName: 'logger-name-1',
   level: 'DEBUG',
@@ -34,17 +34,17 @@ const logger1 = new Logger<LoggerPayload, { filename: string }>({
 })
 
 // Example 1 - Add file name using context that is defined after logger is created
-// context value will be used in transformerFn
+// context value will be used in layoutFn
 const logger2 = new Logger<LoggerPayload, { filename: string }>({
   loggerName: 'logger-name-2',
   level: 'DEBUG',
 })
 logger2.addContext('filename', 'test2.log')
 
-// `TransformerFnInferred` is used to infer transform function parameters:
+// `LayoutFnInferred` is used to infer layout function parameters:
 // `event`, `_logWriterName`, `_logWriterConfig`
-// Can also use `TransformerFn` but it requires more input
-const transformerFn: TransformerFnInferred<typeof logger1, typeof logWriter> = (
+// Can also use `LayoutFn` but it requires more input
+const layoutFn: LayoutFnInferred<typeof logger1, typeof logWriter> = (
   event,
   _logWriterName,
   _logWriterConfig
@@ -54,8 +54,8 @@ const transformerFn: TransformerFnInferred<typeof logger1, typeof logWriter> = (
   return { filename: filename, data: param.join(': ') }
 }
 
-logWriter.register(logger1, 'DEBUG', transformerFn)
-logWriter.register(logger2, 'DEBUG', transformerFn)
+logWriter.register(logger1, 'DEBUG', layoutFn)
+logWriter.register(logger2, 'DEBUG', layoutFn)
 
 /** only one argument {filename, data} is accepted */
 type LoggerPayload3 = [{ fileName: string; data: string | number | boolean | Record<string, any> }]
@@ -66,10 +66,10 @@ const logger3 = new Logger<LoggerPayload3>({
   level: 'DEBUG',
 })
 
-// TransformerFnInferred is used to infer transform function parameters
+// LayoutFnInferred is used to infer layout function parameters
 // `event`, `_logWriterName`, `_logWriterConfig`
-// Can also use `TransformerFn` but it requires more input
-const transformerFn3: TransformerFnInferred<typeof logger3, typeof logWriter> = (
+// Can also use `LayoutFn` but it requires more input
+const layoutFn3: LayoutFnInferred<typeof logger3, typeof logWriter> = (
   event,
   _logWriterName,
   _logWriterConfig
@@ -83,7 +83,7 @@ const transformerFn3: TransformerFnInferred<typeof logger3, typeof logWriter> = 
   return { filename: filename, data: data }
 }
 
-logWriter.register(logger3, 'DEBUG', transformerFn3)
+logWriter.register(logger3, 'DEBUG', layoutFn3)
 
 logger1.info(`logger 1 message`, `${new Date().toISOString()}`)
 logger2.info(`logger 2 message`, `${new Date().toISOString()}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
   SplunkHecLogWriterConfig,
   SplunkData,
 } from './logWriters/splunkHecLogWriter'
-export { Logger } from './logger'
+export { Logger, TransformFunctionReturn } from './logger'
 export { getLevelRegistry } from './level'
 export type * from './types'
 export { shutdown } from './eventBus'

--- a/src/logWriter.ts
+++ b/src/logWriter.ts
@@ -14,7 +14,7 @@ export type ShutdownCb = ((e?: Error) => void) | ((e?: Error) => Promise<void>)
 
 export type ShutdownFn = ((cb?: ShutdownCb) => Promise<void>) | ((cb?: ShutdownCb) => void)
 
-export type TransformerFn<
+export type LayoutFn<
   TData extends Array<LoggerArg>,
   TFormattedData,
   TConfigA extends Record<string, any>,
@@ -89,7 +89,7 @@ export abstract class LogWriter<
     levelName: LevelName,
 
     /** callback function that transforms event payload to format accepted by logWriter  */
-    transformer: TransformerFn<
+    layoutFn: LayoutFn<
       TLogger extends Logger<any, any, infer TDataOut> ? TDataOut : never,
       TFormattedData,
       TConfigA,
@@ -103,7 +103,7 @@ export abstract class LogWriter<
       this: LogWriter<TFormattedData, TConfigA>,
       event: LoggingEvent<any, any> // do not use TData and TContext since we are pushing generic listeners
     ) {
-      const data = transformer(event, this.name, this.config)
+      const data = layoutFn(event, this.name, this.config)
 
       this.write(data)
     }.bind(this)
@@ -146,7 +146,7 @@ export abstract class LogWriter<
 
   /**
    * function that writes event data
-   * At this point, data is transformed by the Transformer class
+   * At this point, data is transformed by the registered layout function
    *
    * Warning! Use _write when file writer needs to be used
    */

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,6 +8,8 @@ import { getLevelRegistry } from './level'
 import { getEventBus } from './eventBus'
 import { defaultParseCallStack, ParseCallStackFunction } from './defaultParseCallStack'
 
+export type TransformFunctionReturn<T> = { data: T; error?: Error | Record<string, any> }
+
 /**
  * The top entry is the Error
  */
@@ -96,7 +98,7 @@ export class Logger<
    * - `data` to be send as message payload
    * - `error` that can be used for stacktrace (not used in payload)
    */
-  protected transform = (...args: TData): { data: TDataOut; error?: Error } => {
+  protected transform = (...args: TData): TransformFunctionReturn<TDataOut> => {
     const error = args.find((item: any) => item instanceof Error)
     return { data: args as any, error }
   }
@@ -133,7 +135,7 @@ export class Logger<
     return true
   }
 
-  private _log(level: LevelParam, data: TDataOut, error?: Error) {
+  private _log(level: LevelParam, data: TDataOut, error?: Error | Record<string, any>) {
     debug(`sending log data (${level}) to log writers`)
 
     let callStack

--- a/src/loggingEvent.ts
+++ b/src/loggingEvent.ts
@@ -55,12 +55,26 @@ const serializer = new Serializer()
 type LoggingEventProps<TData, TContext extends Record<string, any>> = {
   loggerName: string
   level: LevelParam
-  /** objects to log */
+
+  /**
+   * Data or errors to log
+   *
+   * Depending on use-cases, errors can be moved to `error` attribute;
+   * If that's the case, registered layout and/or logger transform functions
+   * will need to be updated accordingly
+   */
   data: TData
-  error?: Error
+
+  /**
+   * error object or error export
+   * can he used to differentiate errors from regular data
+   */
+  error?: Error | Record<string, any>
+
   context?: TContext
   /** node process pid (`process.pid`) */
   pid: number
+
   location?: CallStack
   cluster?: {
     /** cluster.worker.id */
@@ -76,11 +90,25 @@ export class LoggingEvent<TData, TContext extends Record<string, any> = never> {
   context: TContext
 
   loggerName: string
-  /** objects to log */
+
+  /**
+   * Data or errors to log
+   *
+   * Depending on use-cases, errors can be moved to `error` attribute;
+   * If that's the case, registered layout and/or logger transform functions
+   * will need to be updated accordingly
+   */
   data: TData
-  error?: Error
+
+  /**
+   * error object or error export
+   * can he used to differentiate errors from regular data
+   */
+  error?: Error | Record<string, any>
+
   /** node process pid (`process.pid`) */
   pid: number
+
   location?: CallStack
   cluster?: {
     /** cluster.worker.id */

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 
 export type EmptyObject = { [K in any]: never }
 
-export type TransformerFn<
+export type LayoutFn<
   // Logger data shape
   D extends Array<LoggerArg> = Array<LoggerArg>,
   // logWriter configs
@@ -89,7 +89,7 @@ export type TransformerFn<
   }
 ) => DA
 
-export type TransformerFnInferred<
+export type LayoutFnInferred<
   TLogger extends Logger<any, any, any>,
   TLogWriter extends LogWriter<any, any>,
 > = (


### PR DESCRIPTION
- [BC] Allow LoggingEvent.error attribute to contain plain object (error export)
- Export TransformFunctionReturn
- [BC] rename TransformerFn -> LayoutFn
- [BC] rename TransformerFnInferred -> LayoutFnInferred